### PR TITLE
US05 - Rename & delete endpoints

### DIFF
--- a/src/main/java/be/restiau/taskboardbackend/api/board/BoardController.java
+++ b/src/main/java/be/restiau/taskboardbackend/api/board/BoardController.java
@@ -2,6 +2,7 @@ package be.restiau.taskboardbackend.api.board;
 
 import be.restiau.taskboardbackend.api.board.dto.BoardResponse;
 import be.restiau.taskboardbackend.api.board.dto.CreateBoardRequest;
+import be.restiau.taskboardbackend.api.board.dto.RenameRequest;
 import be.restiau.taskboardbackend.bll.board.BoardService;
 import be.restiau.taskboardbackend.infra.security.AppUserDetails;
 import jakarta.validation.Valid;
@@ -24,9 +25,28 @@ public class BoardController {
     public ResponseEntity<BoardResponse> create(
             @AuthenticationPrincipal AppUserDetails principal,
             @Valid @RequestBody CreateBoardRequest payload
-    ){
+    ) {
         BoardResponse dto = boardService.create(principal.getUser(), payload.name());
-        URI location = URI.create("api/boards" + dto.id());
+        URI location = URI.create("api/boards/" + dto.id());
         return ResponseEntity.created(location).body(dto);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<BoardResponse> rename(
+            @AuthenticationPrincipal AppUserDetails principal,
+            @PathVariable Long id,
+            @Valid @RequestBody RenameRequest request
+    ) {
+        BoardResponse renamed = boardService.rename(id, principal.getUser().getId(), request.newName());
+        return ResponseEntity.ok(renamed);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal AppUserDetails principal,
+            @PathVariable Long id
+    ) {
+        boardService.delete(id, principal.getUser().getId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/be/restiau/taskboardbackend/api/board/dto/RenameRequest.java
+++ b/src/main/java/be/restiau/taskboardbackend/api/board/dto/RenameRequest.java
@@ -1,0 +1,10 @@
+package be.restiau.taskboardbackend.api.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RenameRequest(
+        @NotBlank @Size(max = 120)
+        String newName
+) {
+}

--- a/src/main/java/be/restiau/taskboardbackend/bll/board/BoardService.java
+++ b/src/main/java/be/restiau/taskboardbackend/bll/board/BoardService.java
@@ -7,4 +7,8 @@ public interface BoardService {
 
     BoardResponse create(User owner, String name);
 
+    BoardResponse rename(Long boardId, Long ownerId, String newName);
+
+    void delete(Long boardId, Long ownerId);
+
 }

--- a/src/main/java/be/restiau/taskboardbackend/dal/BoardRepository.java
+++ b/src/main/java/be/restiau/taskboardbackend/dal/BoardRepository.java
@@ -5,8 +5,14 @@ import be.restiau.taskboardbackend.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    List<Board> findByOwner(User owner);
-    Boolean existsByOwnerIdAndName(Long ownerId, String name);
+    List<Board> findBoardsByOwnerId(Long ownerId);
+
+    Optional<Board> findByIdAndOwnerId(Long id, Long ownerId);
+
+    boolean existsByIdAndOwnerId(Long boardId, Long ownerId);
+
+    boolean existsByOwnerIdAndNameIgnoreCase(Long ownerId, String newName);
 }

--- a/src/test/java/be/restiau/taskboardbackend/bll/board/BoardServiceImplTest.java
+++ b/src/test/java/be/restiau/taskboardbackend/bll/board/BoardServiceImplTest.java
@@ -3,83 +3,117 @@ package be.restiau.taskboardbackend.bll.board;
 import be.restiau.taskboardbackend.api.board.dto.BoardResponse;
 import be.restiau.taskboardbackend.dal.BoardRepository;
 import be.restiau.taskboardbackend.domain.Board;
-import be.restiau.taskboardbackend.domain.BoardColumn;
 import be.restiau.taskboardbackend.domain.User;
 import be.restiau.taskboardbackend.infra.mapper.BoardMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
-@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+@ExtendWith(MockitoExtension.class)
 class BoardServiceImplTest {
 
     @Mock
-    private BoardRepository boardRepository;
+    BoardRepository boardRepository;
     @Mock
-    private BoardMapper boardMapper;
-
+    BoardMapper boardMapper;
     @InjectMocks
-    private BoardServiceImpl boardService;
+    BoardServiceImpl boardService;
 
-    private User owner;
-    private Board board;
+    User owner;
+    Board board;
 
     @BeforeEach
     void setUp() {
         owner = new User();
-        ReflectionTestUtils.setField(owner, "id", 99L);
-        owner.setEmail("john@mail.com");
-
+        ReflectionTestUtils.setField(owner, "id", 1L);
         board = new Board();
-        board.setName("Mon board");
+        board.setName("My board");
         board.setOwner(owner);
-        // id & createdAt simulés après save
-        board.addColumn(new BoardColumn()); // 3 colonnes s’ajouteront dans le service
     }
 
+    /* ---------- CREATE ---------- */
+
     @Test
-    void create_should_persist_board_and_return_dto() {
-        // ------ Arrange ------
-        when(boardMapper.toEntity("Mon board", owner)).thenReturn(board);
+    void create_ok_returns_dto() {
+        when(boardRepository.existsByOwnerIdAndNameIgnoreCase(1L, "My board")).thenReturn(false);
+        when(boardMapper.toEntity("My board", owner)).thenReturn(board);
+        when(boardRepository.save(board)).thenReturn(board);
+        when(boardMapper.toDTO(board))
+                .thenReturn(new BoardResponse(10L, "My board", Instant.now()));
 
-        Board saved = board;                       // même instance mais id + dates simulées
-        ReflectionTestUtils.setField(saved, "id", 1L);
-        Instant now = Instant.now();
-        ReflectionTestUtils.setField(saved, "createdAt", now);
+        BoardResponse dto = boardService.create(owner, "My board");
 
-        when(boardRepository.save(board))
-                .thenReturn(saved);
-        when(boardMapper.toDTO(saved))
-                .thenReturn(new BoardResponse(1L, "Mon board", now));
-
-        // ------ Act ------
-        BoardResponse dto = boardService.create(owner, "Mon board");
-
-        // ------ Assert ------
-        assertThat(dto.id()).isEqualTo(1L);
-        assertThat(dto.name()).isEqualTo("Mon board");
-        assertThat(dto.createdAt()).isEqualTo(now);
-
+        assertThat(dto.name()).isEqualTo("My board");
         verify(boardRepository).save(board);
     }
 
     @Test
-    void create_should_throw_if_name_already_used() {
-        when(boardRepository.existsByOwnerIdAndName(owner.getId(), "Mon board"))
-                .thenReturn(true);
+    void create_duplicateName_throws() {
+        when(boardRepository.existsByOwnerIdAndNameIgnoreCase(1L, "My board")).thenReturn(true);
 
-        assertThatThrownBy(() -> boardService.create(owner, "Mon board"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Board name already used");
-
+        assertThatThrownBy(() -> boardService.create(owner, "My board"))
+                .isInstanceOf(IllegalStateException.class);
         verify(boardRepository, never()).save(any());
     }
+
+    /* ---------- RENAME ---------- */
+
+    @Test
+    void rename_ok() {
+        when(boardRepository.findByIdAndOwnerId(10L, 1L)).thenReturn(Optional.of(board));
+        when(boardRepository.existsByOwnerIdAndNameIgnoreCase(1L, "New")).thenReturn(false);
+        when(boardMapper.toDTO(board))
+                .thenReturn(new BoardResponse(10L, "New", Instant.now()));
+
+        BoardResponse dto = boardService.rename(10L, 1L, "New");
+        assertThat(dto.name()).isEqualTo("New");
+    }
+
+    @Test
+    void rename_duplicateName_throws() {
+        when(boardRepository.findByIdAndOwnerId(10L, 1L)).thenReturn(Optional.of(board));
+        when(boardRepository.existsByOwnerIdAndNameIgnoreCase(1L, "New")).thenReturn(true);
+
+        assertThatThrownBy(() -> boardService.rename(10L, 1L, "New"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void rename_notOwner_throws403() {
+        when(boardRepository.findByIdAndOwnerId(10L, 99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> boardService.rename(10L, 99L, "X"))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    /* ---------- DELETE ---------- */
+
+    @Test
+    void delete_ok() {
+        when(boardRepository.existsByIdAndOwnerId(10L, 1L)).thenReturn(true);
+
+        boardService.delete(10L, 1L);
+
+        verify(boardRepository).deleteById(10L);
+    }
+
+    @Test
+    void delete_notOwner_throws403() {
+        when(boardRepository.existsByIdAndOwnerId(10L, 1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> boardService.delete(10L, 1L))
+                .isInstanceOf(AccessDeniedException.class);
+    }
 }
+


### PR DESCRIPTION
Endpoints PATCH /api/boards/{id}  &  DELETE /api/boards/{id}

• Renommage : payload { "newName": "…" }  
  – validation non vide / ≤ 120 car.  
  – unicité par owner (IllegalStateException → 400)

• Suppression : 204 No Content

• Vérifie que le user connecté est owner ; sinon 403

• Retour BoardResponse (id, name, createdAt) pour le PATCH

Closes #5
